### PR TITLE
Ccp 627 not logged in in the app after web

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
+### Fixed
+- corrected url used in getting current customer for auto login
 
 [0.4.0] - 2018-06-05
 ### Added

--- a/src/modules/app_event_subscribers/autologin.js
+++ b/src/modules/app_event_subscribers/autologin.js
@@ -18,7 +18,7 @@ function requestCurrentCustomer() {
   const clientId = 'ked0n332n5c8opplowtqmc6kb817wot';
   sendAppCommands([
     sendHttpRequest({
-      url: `https://store-r5s844ad.mybigcommerce.com/customer/current.jwt?app_client_id=${clientId}`,
+      url: `https://${window.location.hostname}/customer/current.jwt?app_client_id=${clientId}`,
       serial: CURRENT_CUSTOMER_SERIAL,
       method: 'GET',
     }),


### PR DESCRIPTION
# Pull Request Template

## Description

Corrected issue with the url used in the requestCurrentCustomer method of auto login. This will allow users to be logged in to the app automatically after registration.

## Type of change

- [ X ] Bug fix
- [ ] New feature
- [ ] This change requires a documentation update

## Checklist:

- [ X ] My code follows the style guidelines of this project
- [ X ] I have performed a self-review of my own code
- [ X ] I have commented my code, particularly in hard-to-understand areas
- [ X ] I updated the CHANGELOG.md
